### PR TITLE
Add support for a single carousel item

### DIFF
--- a/Ouroboros.xcodeproj/project.pbxproj
+++ b/Ouroboros.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		D95AA27F1BDA89DE0080C25B /* OuroborosTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OuroborosTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D95AA2841BDA89DE0080C25B /* OuroborosTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OuroborosTests.swift; sourceTree = "<group>"; };
 		D95AA2861BDA89DE0080C25B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D95AA28F1BDA89F30080C25B /* InfiniteCarousel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfiniteCarousel.swift; sourceTree = "<group>"; };
+		D95AA28F1BDA89F30080C25B /* InfiniteCarousel.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = InfiniteCarousel.swift; sourceTree = "<group>"; tabWidth = 4; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */


### PR DESCRIPTION
I manually merged this from:

https://github.com/willowtreeapps/ouroboros/pull/41

Currently, when we try to run the carousel with a single item we’ll crash with the following precondition:

```
precondition(count >= buffer, "Ouroboros requires at least twice the number of items per page to work properly. For best results: a number that is evenly divisible by the number of items per page.")
```

Infinite scrolling is essentially the reason it didn’t work before.  There’s no way to do that with a single item. He added support for non-infinite scroll.

It took a lot of work to manually merge in his changes with Fredricks and with what was different on the origin repo.  There were too many conflicts to do it automatically.